### PR TITLE
Correção do método de envio do código de verificação para ativação do 2FA

### DIFF
--- a/resources/js/2FA/enable.js
+++ b/resources/js/2FA/enable.js
@@ -28,10 +28,10 @@ $(document).ready(function () {
 
         function activateTwoFactor() {
             $.get(routes['two-factor.qr-code'], function (response) {
-                $('#twoFactorForm').html(`<div class="flex justify-center">${response.svg}</div>`);
+                $('#twoFactorForm').html(`<div class="m-auto w-55"><div class="flex justify-center bg-white p-2">${response.svg}</div></div>`);
                 $('#twoFactorForm').attr('action', routes['two-factor.confirm']);
                 $('#twoFactorForm').append(`<p class="text-center dark:text-white">${translations.enable2FACode}</p>`);
-                $('#twoFactorForm').append(`<div class="mb-5 size-64 m-auto h-20"><label for="iconfirmCode" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">${translations.code}</label><input type="text" id="iconfirmCode" name="confirmCode" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="123456" required autofocus /></div>`);
+                $('#twoFactorForm').append(`<div class="mb-5 size-64 m-auto h-20"><label for="icode" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">${translations.code}</label><input type="text" id="icode" name="code" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="123456" required autofocus /></div>`);
 
                 $('#twoFactorForm').append(`<div class="flex justify-center"><button class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800 cursor-pointer">${translations.submit}</button></div>`);
             });

--- a/resources/js/2FA/enable.js
+++ b/resources/js/2FA/enable.js
@@ -13,28 +13,36 @@ $(document).ready(function () {
 
         $.post(url)
             .done(function () {
-                if (url == routes['two-factor.confirm']) {
-                    $('#twoFactorForm').html(`<p class="text-center dark:text-white">${translations.success2FA}</p>`);
-                } else {
-                    activateTwoFactor();
-                }
+                $.get(routes['two-factor.qr-code'], function (response) {
+                    $('#form').html(`<div class="m-auto w-55"><div class="flex justify-center bg-white p-2">${response.svg}</div></div>`);
+
+                    $('#form').append(`<p class="text-center dark:text-white">${translations.enable2FACode}</p>`);
+                    $('#form').append(`<div class="mb-5 size-64 m-auto h-20"><label for="icode" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">${translations.code}</label><input type="text" id="icode" name="code" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="123456" required autofocus /></div>`);
+
+                    $('#form').append(`<div class="flex justify-center"><button id="twoFactorConfirmCodeSubmit" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800 cursor-pointer">${translations.submit}</button></div>`);
+                });
             }).fail(function (error) {
-                if (url == routes['two-factor.confirm']) {
-                    $('#twoFactorForm').html(`<p class="text-center dark:text-white">${translations.invalid2FACode}</p>`);
+                window.location.href = routes['password.confirm'];
+            });
+
+    });
+
+    // TODO: finalizar o post do formulário de confirmação do código 2FA
+    $('#twoFactorConfirmCodeSubmit').click(function (e) {
+        e.preventDefault();
+
+        $.post(
+            routes['two-factor.confirm'],
+
+        )
+            .done(function () {
+                window.location.href = routes['two-factor.index'];
+            }).fail(function (error) {
+                if (error.status === 422) {
+                    $('#twoFactorConfirmCode').html(`<div class="text-red-500">${translations.codeError}</div>`);
                 } else {
                     window.location.href = routes['password.confirm'];
                 }
             });
-
-        function activateTwoFactor() {
-            $.get(routes['two-factor.qr-code'], function (response) {
-                $('#twoFactorForm').html(`<div class="m-auto w-55"><div class="flex justify-center bg-white p-2">${response.svg}</div></div>`);
-                $('#twoFactorForm').attr('action', routes['two-factor.confirm']);
-                $('#twoFactorForm').append(`<p class="text-center dark:text-white">${translations.enable2FACode}</p>`);
-                $('#twoFactorForm').append(`<div class="mb-5 size-64 m-auto h-20"><label for="icode" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">${translations.code}</label><input type="text" id="icode" name="code" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="123456" required autofocus /></div>`);
-
-                $('#twoFactorForm').append(`<div class="flex justify-center"><button class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800 cursor-pointer">${translations.submit}</button></div>`);
-            });
-        }
-    });
+    })
 });

--- a/resources/views/profile/settings.blade.php
+++ b/resources/views/profile/settings.blade.php
@@ -3,7 +3,24 @@
         @vite(['resources/js/2FA/enable.js'])
     </x-slot:head>
 
-    <form id="twoFactorForm" method="POST" action="{{ route('two-factor.enable') }}">
-        <x-navigation.button text="Ativar autenticação em dois fatores" />
-    </form>
+    @if (Auth::user()->two_factor_confirmed_at)
+        já eativo
+
+        @if (!session()->has('auth.password_confirmed_at') ||
+        time() - session('auth.password_confirmed_at') > config('auth.password_timeout', 10800))
+
+        <a href="/confirm-password" class="link-primary link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover fs-4">Confirme a senha para ver seus códigos de autenticação</a>
+        @else
+        <button id="getCodes" class="btn btn-primary">Visualizar códigos de recuperação</button>
+        <button id="newCodes" class="btn btn-warning">Gerar novos códigos</button>
+        @endif
+
+    @else
+    <div id="form">
+        <form id="twoFactorForm" method="POST" action="{{ route('two-factor.enable') }}">
+            <x-navigation.button text="Ativar autenticação em dois fatores" />
+        </form>
+    </div>
+
+    @endif
 </x-layouts.main>


### PR DESCRIPTION
O método anterior adicionava um input:text no mesmo formulário gerado para ativar a autenticação, o que fazia com que o mesmo não fosse enviado automaticamente no pedido, pois deve ser adicionado ao corpo da requisição ajax. 
Essa atualização separa os formulários em duas partes permitindo finalizar esse envio de maneira correta