### PR TITLE
Getting video data - Correção da maneira como o caminho do vídeo é armazenado

### DIFF
--- a/laravel-api/app/Http/Controllers/ProfileController.php
+++ b/laravel-api/app/Http/Controllers/ProfileController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Services\VideoProcessingService;
 use App\Services\VideoService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -36,8 +35,8 @@ class ProfileController extends Controller
 
         $filePaths = $this->videoService->storageNewUploadedVideoFiles($data['video'], $data['thumbnail']);
 
-        $this->videoService->convertToHLS(Storage::disk('local')->path($filePaths['video']));
-   
+        $this->videoService->convertToHLS(Storage::disk('local')->path('videos/' . $filePaths['video']));
+
         $this->videoService->createVideo(
             $data['title'],
             $data['description'],

--- a/laravel-api/app/Http/Controllers/ProfileController.php
+++ b/laravel-api/app/Http/Controllers/ProfileController.php
@@ -35,13 +35,13 @@ class ProfileController extends Controller
 
         $filePaths = $this->videoService->storageNewUploadedVideoFiles($data['video'], $data['thumbnail']);
 
-        $this->videoService->convertToHLS(Storage::disk('local')->path('videos/' . $filePaths['video']));
+        $this->videoService->convertToHLS(Storage::disk('local')->path($filePaths['video']));
 
         $this->videoService->createVideo(
             $data['title'],
             $data['description'],
             $data['categories'],
-            $filePaths['video'],
+            pathinfo($filePaths['video'], PATHINFO_FILENAME),
             $filePaths['thumbnail']
         );
 

--- a/laravel-api/app/Http/Controllers/VideoController.php
+++ b/laravel-api/app/Http/Controllers/VideoController.php
@@ -79,7 +79,7 @@ class VideoController extends Controller
             [
                 'title' => $video->title,
                 'description' => $video->description,
-                'video_path' => $video->video_path,
+                'video_file' => $video->video_path,
             ],
             200
         );

--- a/laravel-api/app/Services/VideoService.php
+++ b/laravel-api/app/Services/VideoService.php
@@ -173,8 +173,8 @@ class VideoService
      */
     public function storageNewUploadedVideoFiles($video, $thumbnail): array
     {
-        $videoPath = $this->storageVideo($video);
-        $thumbnailPath = $this->storageThumbnail($thumbnail);
+        $videoPath = pathinfo($this->storageVideo($video), PATHINFO_BASENAME);
+        $thumbnailPath = pathinfo($this->storageThumbnail($thumbnail), PATHINFO_BASENAME);
 
         return [
             'video' => $videoPath,

--- a/laravel-api/app/Services/VideoService.php
+++ b/laravel-api/app/Services/VideoService.php
@@ -173,8 +173,8 @@ class VideoService
      */
     public function storageNewUploadedVideoFiles($video, $thumbnail): array
     {
-        $videoPath = pathinfo($this->storageVideo($video), PATHINFO_BASENAME);
-        $thumbnailPath = pathinfo($this->storageThumbnail($thumbnail), PATHINFO_BASENAME);
+        $videoPath = $this->storageVideo($video);
+        $thumbnailPath = $this->storageThumbnail($thumbnail);
 
         return [
             'video' => $videoPath,

--- a/laravel-api/tests/Feature/Controllers/VideoControllerTest.php
+++ b/laravel-api/tests/Feature/Controllers/VideoControllerTest.php
@@ -126,7 +126,7 @@ class VideoControllerTest extends TestCase
         $response->assertJsonStructure([
             'title',
             'description',
-            'video_path',
+            'video_file',
         ]);
     }
 }

--- a/laravel-api/tests/Feature/Services/VideoServiceTest.php
+++ b/laravel-api/tests/Feature/Services/VideoServiceTest.php
@@ -39,27 +39,23 @@ class VideoServiceTest extends TestCase
         ];
 
         // Act
-        $filePaths = $this->videoService->storageNewUploadedVideoFiles(
+        $filesBasename = $this->videoService->storageNewUploadedVideoFiles(
             $data['video'],
             $data['thumbnail']
         );
 
         // Assert
-        $this->assertIsArray($filePaths);
-        $this->assertArrayHasKey('video', $filePaths);
-        $this->assertArrayHasKey('thumbnail', $filePaths);
-
-        // Verify that files were stored in the correct directories
-        $this->assertTrue(str_starts_with($filePaths['video'], 'videos/'));
-        $this->assertTrue(str_starts_with($filePaths['thumbnail'], 'thumbnails/'));
+        $this->assertIsArray($filesBasename);
+        $this->assertArrayHasKey('video', $filesBasename);
+        $this->assertArrayHasKey('thumbnail', $filesBasename);
 
         // Verify that the files actually exist in storage
-        Storage::assertExists($filePaths['video']);
-        Storage::assertExists($filePaths['thumbnail']);
+        Storage::assertExists('videos/' . $filesBasename['video']);
+        Storage::assertExists('thumbnails/' . $filesBasename['thumbnail']);
 
         // Verify file types (optional but good practice)
-        $this->assertStringContainsString('.mp4', $filePaths['video']);
-        $this->assertStringContainsString('.jpg', $filePaths['thumbnail']);
+        $this->assertStringContainsString('.mp4', $filesBasename['video']);
+        $this->assertStringContainsString('.jpg', $filesBasename['thumbnail']);
     }
 
     public function test_if_can_register_new_video_data(): void

--- a/laravel-api/tests/Feature/Services/VideoServiceTest.php
+++ b/laravel-api/tests/Feature/Services/VideoServiceTest.php
@@ -39,23 +39,23 @@ class VideoServiceTest extends TestCase
         ];
 
         // Act
-        $filesBasename = $this->videoService->storageNewUploadedVideoFiles(
+        $filePath = $this->videoService->storageNewUploadedVideoFiles(
             $data['video'],
             $data['thumbnail']
         );
 
         // Assert
-        $this->assertIsArray($filesBasename);
-        $this->assertArrayHasKey('video', $filesBasename);
-        $this->assertArrayHasKey('thumbnail', $filesBasename);
+        $this->assertIsArray($filePath);
+        $this->assertArrayHasKey('video', $filePath);
+        $this->assertArrayHasKey('thumbnail', $filePath);
 
         // Verify that the files actually exist in storage
-        Storage::assertExists('videos/' . $filesBasename['video']);
-        Storage::assertExists('thumbnails/' . $filesBasename['thumbnail']);
+        Storage::assertExists($filePath['video']);
+        Storage::assertExists($filePath['thumbnail']);
 
         // Verify file types (optional but good practice)
-        $this->assertStringContainsString('.mp4', $filesBasename['video']);
-        $this->assertStringContainsString('.jpg', $filesBasename['thumbnail']);
+        $this->assertStringContainsString('.mp4', $filePath['video']);
+        $this->assertStringContainsString('.jpg', $filePath['thumbnail']);
     }
 
     public function test_if_can_register_new_video_data(): void

--- a/vue-spa/src/components/cards/VideoCard.vue
+++ b/vue-spa/src/components/cards/VideoCard.vue
@@ -7,7 +7,7 @@ const props = defineProps({
     thumb_file: String,
 })
 
-const thumb_path = back_url + '/api/video/thumb/' + props.thumb_file.replace('thumbnails/', '')
+const thumb_path = back_url + '/api/video/thumb/' + props.thumb_file
 </script>
 
 <template>

--- a/vue-spa/src/views/video/Render.vue
+++ b/vue-spa/src/views/video/Render.vue
@@ -19,7 +19,7 @@ const videoCommentsTotalPages = ref(1);
 const videoData = reactive({
     title: "",
     description: "",
-    video_path: ""
+    videoFile: ""
 });
 
 onMounted(async () => {
@@ -27,7 +27,7 @@ onMounted(async () => {
         .then((response) => {
             videoData.title = response.data.title;
             videoData.description = response.data.description;
-            videoData.video_path = response.data.video_path;
+            videoData.videoFile = response.data.video_file;
         })
         .catch((error) => {
             console.error(error);
@@ -68,11 +68,11 @@ const translations = getTranslations();
     <MainLayout>
         <!-- Main -->
         <section id="video-container" class="mx-auto my-5 w-[100dvw] md:w-[80dvw]">
-            <VideoPlayer :videoPath="videoData.video_path" />
+            <VideoPlayer :video_file="videoData.videoFile" />
         </section>
 
         <div class="max-w-[1200px] m-auto grid grid-cols-1 md:grid-cols-2 md:grid-rows-1 gap-4
-               bg-gray-100 dark:bg-gray-800 rounded-lg shadow-md p-6">
+        bg-gray-100 dark:bg-gray-800 rounded-lg shadow-md p-6">
             <section id="video-data"
                 class="border-b md:border-b-0 md:border-r border-gray-300 dark:border-gray-700 pr-4 pb-4 md:pb-0 md:pr-6">
                 <h1 class="text-2xl font-bold mb-2 text-gray-900 dark:text-gray-100 break-words whitespace-pre-line">


### PR DESCRIPTION
Agora apenas o nome único do caminho do vídeo é armazenado no banco de dados, sem caminho e extensão